### PR TITLE
feat: harden raff pre-commit mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,10 +74,10 @@ raff <COMMAND> --help
 ## Pre-Commit Hook Integration 🔗
 
 raff includes a built-in `pre-commit` profile optimized for use as a pre-commit hook. This profile:
-- Runs only fast rules (statement-count, coupling) - skips slow volatility analysis
-- Analyzes only git-staged files via `git diff --name-only --cached`
-- Uses minimal output (summary line only)
-- Applies a more lenient threshold (25% vs 15% default)
+- Analyzes only git-staged changes
+- Uses fast, read-only coupling checks suitable for commit hooks
+- Prints a single-line summary on success and a CLI table on failure
+- Fails the hook when it finds warnings or errors
 
 ### Configuration
 
@@ -92,19 +92,20 @@ repos:
         entry: raff --profile pre-commit all
         language: system
         pass_filenames: false
-        always_run: true
+        files: '(^|/)Cargo\.toml$|(^|/)Cargo\.lock$|(^|/)rust-toolchain(\.toml)?$|^\.cargo/|\.rs$'
 ```
 
 ### Pre-Commit Profile Settings
 
-The pre-commit profile can be customized in `.raff/raff.toml`:
+The built-in defaults work without any extra configuration. If you want to override them,
+the pre-commit profile can be customized in `.raff/raff.toml`:
 
 ```toml
 [profile.pre_commit]
-fast = true      # Skip slow volatility analysis
-staged = true    # Only analyze staged files
-quiet = true     # Minimal output
-sc_threshold = 25  # Lenient threshold (vs 15% default)
+fast = true
+staged = true
+quiet = true
+sc_threshold = 25
 ```
 
 ### Manual Testing

--- a/examples/all_rules_example.rs
+++ b/examples/all_rules_example.rs
@@ -8,6 +8,7 @@ fn main() -> Result<()> {
         output: AllOutputFormat::Html,
         fast: false,
         quiet: false,
+        fail_on_warnings: false,
         sc_threshold: 10,
         vol_alpha: 0.01,
         vol_since: None,

--- a/src/all_rules.rs
+++ b/src/all_rules.rs
@@ -23,6 +23,7 @@
 //!     output: AllOutputFormat::Json,
 //!     fast: false,
 //!     quiet: false,
+//!     fail_on_warnings: false,
 //!     staged: false,
 //!     // .. other fields
 //!     sc_threshold: 10,
@@ -157,9 +158,14 @@ pub fn run_all(args: &AllArgs) -> Result<()> {
     };
 
     let all_data = if args.fast {
-        // Fast mode: only run statement-count and coupling (skip volatility and rust-code-analysis)
+        // In staged fast mode, skip statement-count because component-percentage
+        // metrics over a staged subset are not meaningful.
         AllReportData {
-            statement_count: Some(sc_rule.analyze(&sc_args)),
+            statement_count: if args.staged {
+                None
+            } else {
+                Some(sc_rule.analyze(&sc_args))
+            },
             volatility: None,
             coupling: Some(coup_rule.analyze(&coup_args)),
             rust_code_analysis: None,
@@ -249,7 +255,7 @@ pub fn run_all(args: &AllArgs) -> Result<()> {
             // Sort by severity (Error first) then rule
             all_findings.sort_by_key(|f| (!f.severity.is_error(), f.rule_id.clone()));
 
-            if args.quiet {
+            if args.quiet && all_findings.is_empty() {
                 let summary = crate::cli_report::render_summary_line(&all_findings);
                 println!("{summary}");
             } else {
@@ -259,11 +265,12 @@ pub fn run_all(args: &AllArgs) -> Result<()> {
 
             // Return error if any findings are Error severity
             let has_errors = all_findings.iter().any(|f| f.severity == Severity::Error);
-            if has_errors {
+            let should_fail_on_findings = args.fail_on_warnings && !all_findings.is_empty();
+            if has_errors || should_fail_on_findings {
                 return Err(crate::error::RaffError::analysis_error(
                     "all",
                     format!(
-                        "Found {} issue{} ({} error{})",
+                        "Found {} issue{} ({} error{}, {} warning{})",
                         all_findings.len(),
                         if all_findings.len() == 1 { "" } else { "s" },
                         all_findings
@@ -273,6 +280,20 @@ pub fn run_all(args: &AllArgs) -> Result<()> {
                         if all_findings
                             .iter()
                             .filter(|f| f.severity == Severity::Error)
+                            .count()
+                            == 1
+                        {
+                            ""
+                        } else {
+                            "s"
+                        },
+                        all_findings
+                            .iter()
+                            .filter(|f| f.severity == Severity::Warning)
+                            .count(),
+                        if all_findings
+                            .iter()
+                            .filter(|f| f.severity == Severity::Warning)
                             .count()
                             == 1
                         {
@@ -370,6 +391,7 @@ mod tests {
             output: AllOutputFormat::Json,
             fast: false,
             quiet: false,
+            fail_on_warnings: false,
             sc_threshold: 10,
             vol_alpha: 0.01,
             vol_since: None,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -297,9 +297,14 @@ pub struct AllArgs {
     pub fast: bool,
 
     /// Minimal output (summary line only).
-    /// Suppresses the full table output and prints only a single-line summary.
+    /// Prints a summary when there are no findings, and a full table when there are.
     #[clap(long)]
     pub quiet: bool,
+
+    /// Treat warnings as failures.
+    /// Useful for deterministic quality gates such as pre-commit hooks.
+    #[clap(long)]
+    pub fail_on_warnings: bool,
 
     /// Percentage threshold for component size (0-100).
     #[clap(long, default_value_t = 10)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -324,31 +324,29 @@ pub struct PreCommitSettings {
 /// ```
 #[must_use]
 pub fn apply_pre_commit_profile(config: &RaffConfig) -> PreCommitSettings {
-    let pc = match &config.profile.pre_commit {
-        Some(p) => p,
-        None => {
-            return PreCommitSettings {
-                config: config.clone(),
-                fast: false,
-                staged: false,
-                quiet: false,
-            };
-        }
-    };
+    let default_fast = true;
+    let default_staged = true;
+    let default_quiet = true;
+    let default_sc_threshold = 25;
+    let pc = config.profile.pre_commit.as_ref();
 
     let mut result = config.clone();
 
     // Apply statement count threshold from profile if set
-    if let Some(threshold) = pc.sc_threshold {
-        result.statement_count.threshold = threshold;
-    }
+    result.statement_count.threshold = pc
+        .and_then(|profile| profile.sc_threshold)
+        .unwrap_or(default_sc_threshold);
 
     // Return profile settings for runtime behavior
     PreCommitSettings {
         config: result,
-        fast: pc.fast.unwrap_or(false),
-        staged: pc.staged.unwrap_or(false),
-        quiet: pc.quiet.unwrap_or(false),
+        fast: pc.and_then(|profile| profile.fast).unwrap_or(default_fast),
+        staged: pc
+            .and_then(|profile| profile.staged)
+            .unwrap_or(default_staged),
+        quiet: pc
+            .and_then(|profile| profile.quiet)
+            .unwrap_or(default_quiet),
     }
 }
 
@@ -827,6 +825,7 @@ pub fn merge_all_args(cli_args: &crate::cli::AllArgs, config: &RaffConfig) -> cr
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serial_test::serial;
     use std::io::Write;
     use std::process::Command;
     use tempfile::NamedTempFile;
@@ -1002,6 +1001,7 @@ decay = 0.05
     }
 
     #[test]
+    #[serial(cwd)]
     fn test_discover_and_load_config_finds_raff_toml() {
         let temp_dir = TempDir::new().expect("Failed to create temp dir");
         let config_path = temp_dir.path().join("Raff.toml");
@@ -1045,6 +1045,7 @@ verbose = true
     }
 
     #[test]
+    #[serial(cwd)]
     fn test_discover_and_load_config_finds_dot_raff_toml() {
         let temp_dir = TempDir::new().expect("Failed to create temp dir");
         let config_path = temp_dir.path().join(".raff.toml");
@@ -1085,6 +1086,7 @@ threshold = 50
     }
 
     #[test]
+    #[serial(cwd)]
     fn test_discover_and_load_config_returns_none_when_no_config() {
         let temp_dir = TempDir::new().expect("Failed to create temp dir");
 
@@ -1138,6 +1140,7 @@ alpha = 0.1
     }
 
     #[test]
+    #[serial(cwd)]
     fn test_load_config_with_none_path_discovers_config() {
         let temp_dir = TempDir::new().expect("Failed to create temp dir");
         let config_path = temp_dir.path().join("Raff.toml");
@@ -1460,6 +1463,7 @@ verbose = true
             output: crate::cli::AllOutputFormat::Html,
             fast: false,
             quiet: false,
+            fail_on_warnings: false,
             sc_threshold: 10,
             vol_alpha: 0.01,
             vol_since: None,
@@ -1688,25 +1692,21 @@ sc_threshold = 15
     }
 
     #[test]
-    fn test_apply_pre_commit_profile_with_no_profile_returns_config_unchanged() {
+    fn test_apply_pre_commit_profile_with_no_profile_returns_built_in_defaults() {
         let config = RaffConfig::default();
-        let original_threshold = config.statement_count.threshold;
 
         let result = apply_pre_commit_profile(&config);
 
         assert_eq!(
-            result.config.statement_count.threshold, original_threshold,
-            "threshold should remain unchanged when no profile is set"
+            result.config.statement_count.threshold, 25,
+            "threshold should fall back to the built-in pre-commit default"
         );
-        assert!(!result.fast, "fast should be false when no profile is set");
+        assert!(result.fast, "fast should default to true for pre-commit");
         assert!(
-            !result.staged,
-            "staged should be false when no profile is set"
+            result.staged,
+            "staged should default to true for pre-commit"
         );
-        assert!(
-            !result.quiet,
-            "quiet should be false when no profile is set"
-        );
+        assert!(result.quiet, "quiet should default to true for pre-commit");
     }
 
     #[test]
@@ -1780,15 +1780,9 @@ sc_threshold = 15
             result.config.statement_count.threshold, 30,
             "only sc_threshold should be applied"
         );
-        assert!(!result.fast, "fast should be false when not set in profile");
-        assert!(
-            !result.staged,
-            "staged should be false when not set in profile"
-        );
-        assert!(
-            !result.quiet,
-            "quiet should be false when not set in profile"
-        );
+        assert!(result.fast, "fast should default to true when not set");
+        assert!(result.staged, "staged should default to true when not set");
+        assert!(result.quiet, "quiet should default to true when not set");
     }
 
     #[test]
@@ -1834,6 +1828,7 @@ sc_threshold = 15
     }
 
     #[test]
+    #[serial(cwd)]
     fn test_discover_and_load_config_finds_raff_directory_config() {
         let temp_dir = TempDir::new().expect("Failed to create temp dir");
 
@@ -1899,6 +1894,7 @@ threshold = 15
     }
 
     #[test]
+    #[serial(cwd)]
     fn test_discover_and_load_config_prioritizes_local_config_over_raff_directory() {
         let temp_dir = TempDir::new().expect("Failed to create temp dir");
 
@@ -1971,6 +1967,7 @@ threshold = 50
     }
 
     #[test]
+    #[serial(cwd)]
     fn test_discover_and_load_config_finds_raff_directory_from_subdirectory() {
         let temp_dir = TempDir::new().expect("Failed to create temp dir");
 
@@ -2031,6 +2028,7 @@ granularity = "module"
     }
 
     #[test]
+    #[serial(cwd)]
     fn test_discover_and_load_config_returns_none_when_only_raff_dir_exists_but_no_config() {
         let temp_dir = TempDir::new().expect("Failed to create temp dir");
 

--- a/src/coupling_rule.rs
+++ b/src/coupling_rule.rs
@@ -99,14 +99,14 @@ use std::process::Command;
 use syn::{ExprPath, Item, ItemMod, ItemUse, PatType, visit::Visit};
 use walkdir::WalkDir;
 
-#[derive(Debug, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 struct CargoMetadata {
     packages: Vec<Package>,
     workspace_members: Vec<String>,
     resolve: Option<Resolve>,
 }
 
-#[derive(Debug, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 struct Package {
     id: String,
     name: String,
@@ -118,23 +118,23 @@ struct Package {
 #[allow(dead_code)]
 struct PkgId(String);
 
-#[derive(Debug, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 struct Dependency {
     name: String,
 }
 
-#[derive(Debug, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 struct Resolve {
     nodes: Vec<ResolveNode>,
 }
 
-#[derive(Debug, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 struct ResolveNode {
     id: String,
     dependencies: Vec<String>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Serialize, Deserialize)]
 struct CrateLevelAnalysisResult {
     crate_couplings_map: HashMap<String, CrateCoupling>,
     workspace_packages_map: HashMap<String, Package>,
@@ -310,12 +310,23 @@ impl CouplingRule {
         let workspace_packages_map = analysis_result.workspace_packages_map;
         let package_id_to_name = analysis_result.package_id_to_name;
         let workspace_member_ids = analysis_result.workspace_member_ids;
+        let affected_crates = if args.staged {
+            Some(self.detect_affected_crates(&workspace_packages_map)?)
+        } else {
+            None
+        };
 
         let mut full_report = CouplingData {
             crates: Vec::new(),
             granularity: args.granularity.clone(),
             analysis_path: args.path.clone(),
         };
+
+        if let Some(affected_crates) = affected_crates.as_ref()
+            && affected_crates.is_empty()
+        {
+            return Ok(full_report);
+        }
 
         let mut sorted_workspace_pkg_ids: Vec<_> = workspace_member_ids.iter().cloned().collect();
         sorted_workspace_pkg_ids
@@ -324,6 +335,11 @@ impl CouplingRule {
         for pkg_id in sorted_workspace_pkg_ids {
             if let Some(pkg_data) = workspace_packages_map.get(&pkg_id) {
                 let crate_name = &pkg_data.name;
+                if let Some(affected_crates) = affected_crates.as_ref()
+                    && !affected_crates.contains(crate_name)
+                {
+                    continue;
+                }
                 let mut current_crate_coupling = crate_couplings_map
                     .get(crate_name)
                     .cloned()
@@ -401,6 +417,8 @@ impl CouplingRule {
             .arg("metadata")
             .arg("--format-version")
             .arg("1")
+            .arg("--locked")
+            .arg("--no-deps")
             .current_dir(analysis_path)
             .output()?;
         if !metadata_output.status.success() {
@@ -481,8 +499,8 @@ impl CouplingRule {
                 }
             }
         } else {
-            eprintln!(
-                "Warning: 'resolve' graph not found in cargo metadata. Crate coupling might be inaccurate using fallback."
+            tracing::debug!(
+                "cargo metadata did not include a resolve graph; using dependency-list fallback"
             );
             let workspace_package_names_to_ids: HashMap<String, String> = workspace_packages_map
                 .values()
@@ -524,6 +542,35 @@ impl CouplingRule {
             package_id_to_name,
             workspace_member_ids,
         })
+    }
+
+    fn detect_affected_crates(
+        &self,
+        workspace_packages_map: &HashMap<String, Package>,
+    ) -> Result<HashSet<String>> {
+        let staged_files = crate::git_utils::get_staged_files()?;
+        if staged_files.is_empty() {
+            return Ok(HashSet::new());
+        }
+
+        let mut affected = HashSet::new();
+        for package in workspace_packages_map.values() {
+            let manifest_path = PathBuf::from(&package.manifest_path);
+            let Some(package_dir) = manifest_path.parent() else {
+                continue;
+            };
+            let canonical_package_dir = package_dir
+                .canonicalize()
+                .unwrap_or_else(|_| package_dir.to_path_buf());
+            if staged_files
+                .iter()
+                .any(|file| file.starts_with(&canonical_package_dir))
+            {
+                affected.insert(package.name.clone());
+            }
+        }
+
+        Ok(affected)
     }
 
     #[tracing::instrument(level = "debug", skip(self, _pkg_data), ret)]

--- a/src/git_utils.rs
+++ b/src/git_utils.rs
@@ -45,10 +45,16 @@ pub fn get_staged_files() -> Result<Vec<PathBuf>> {
     }
 
     let content = String::from_utf8_lossy(&output.stdout);
+    let repo_root = get_repo_root()?;
     let files: Vec<PathBuf> = content
         .lines()
         .filter(|line| !line.is_empty())
         .map(PathBuf::from)
+        .map(|path| match (&repo_root, path.is_absolute()) {
+            (_, true) => path,
+            (Some(root), false) => root.join(path),
+            (None, false) => path,
+        })
         .collect();
 
     tracing::debug!("Found {} staged files", files.len());
@@ -377,8 +383,8 @@ mod tests {
         );
         assert_eq!(
             files[0],
-            PathBuf::from("test.rs"),
-            "get_staged_files should return the correct file name"
+            temp_dir.path().join("test.rs"),
+            "get_staged_files should return an absolute path under the repo root"
         );
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,11 +2,11 @@
 
 use clap::Parser;
 use raff_core::{
-    CacheManager, Cli, Commands, ConfigSourceType, ContributorReportRule, CouplingRule,
-    RustCodeAnalysisRule, StatementCountRule, VolatilityRule, all_rules, apply_pre_commit_profile,
-    error::Result, load_hierarchical_config, merge_all_args, merge_contributor_report_args,
-    merge_coupling_args, merge_rust_code_analysis_args, merge_statement_count_args,
-    merge_volatility_args,
+    AllOutputFormat, CacheManager, Cli, Commands, ConfigSourceType, ContributorReportRule,
+    CouplingGranularity, CouplingRule, RustCodeAnalysisRule, StatementCountRule, VolatilityRule,
+    all_rules, apply_pre_commit_profile, error::RaffError, error::Result, load_hierarchical_config,
+    merge_all_args, merge_contributor_report_args, merge_coupling_args,
+    merge_rust_code_analysis_args, merge_statement_count_args, merge_volatility_args,
 };
 use std::process::exit;
 
@@ -64,19 +64,19 @@ fn main() -> Result<()> {
     }
 
     // Apply profile if requested via --profile flag
-    let (config, profile_fast, profile_staged, profile_quiet) =
-        if cli_args.profile.as_deref() == Some("pre-commit") {
-            tracing::info!("Applying pre-commit profile configuration");
-            let settings = apply_pre_commit_profile(&hierarchical_result.merged);
-            (
-                settings.config,
-                settings.fast,
-                settings.staged,
-                settings.quiet,
-            )
-        } else {
-            (hierarchical_result.merged.clone(), false, false, false)
-        };
+    let pre_commit_profile_active = cli_args.profile.as_deref() == Some("pre-commit");
+    let (config, profile_fast, profile_staged, profile_quiet) = if pre_commit_profile_active {
+        tracing::info!("Applying pre-commit profile configuration");
+        let settings = apply_pre_commit_profile(&hierarchical_result.merged);
+        (
+            settings.config,
+            settings.fast,
+            settings.staged,
+            settings.quiet,
+        )
+    } else {
+        (hierarchical_result.merged.clone(), false, false, false)
+    };
 
     let run_result = match cli_args.command {
         Commands::StatementCount(mut args) => {
@@ -129,6 +129,13 @@ fn main() -> Result<()> {
             let mut merged_args = merge_all_args(&args, &config);
             // Propagate global staged flag and profile staged setting
             merged_args.staged = cli_args.staged || profile_staged || args.staged;
+            if pre_commit_profile_active {
+                merged_args.output = AllOutputFormat::Cli;
+                merged_args.fail_on_warnings = true;
+                if matches!(merged_args.coup_granularity, CouplingGranularity::Both) {
+                    merged_args.coup_granularity = CouplingGranularity::Crate;
+                }
+            }
             tracing::info!("Running all rules with args: {:?}", merged_args);
             all_rules::run_all(&merged_args)
         }
@@ -144,8 +151,9 @@ fn main() -> Result<()> {
     };
 
     if let Err(e) = run_result {
-        // Using color-eyre's report format
-        eprintln!("{e:?}");
+        if !matches!(e, RaffError::AnalysisError { .. }) {
+            eprintln!("{e}");
+        }
         exit(1);
     }
 

--- a/src/statement_count_rule.rs
+++ b/src/statement_count_rule.rs
@@ -252,16 +252,24 @@ impl StatementCountRule {
         let threshold = args.threshold;
         let analysis_path = &args.path;
 
-        // Create cache key from analysis path and threshold
-        let cache_manager = CacheManager::new()?;
         let cache_key = CacheKey::new(
             format!("statement_count:{}", analysis_path.display()),
             None, // No git state for statement count
-            vec![("threshold".to_string(), threshold.to_string())],
+            vec![
+                ("threshold".to_string(), threshold.to_string()),
+                ("staged".to_string(), args.staged.to_string()),
+            ],
         );
+        let cache_manager = if args.staged {
+            None
+        } else {
+            Some(CacheManager::new()?)
+        };
 
-        // Try to get cached result
-        if let Some(cached_entry) = cache_manager.get(&cache_key)? {
+        // Try to get cached result for full-repo analysis only.
+        if let Some(cache_manager) = cache_manager.as_ref()
+            && let Some(cached_entry) = cache_manager.get(&cache_key)?
+        {
             tracing::info!("Using cached statement count analysis result");
             let cached_data: StatementCountData = bincode::deserialize(&cached_entry.data)
                 .map_err(|e| {
@@ -352,8 +360,10 @@ impl StatementCountRule {
                 e
             ))
         })?;
-        let cache_entry = CacheEntry::new(serialized_data);
-        cache_manager.put(&cache_key, cache_entry)?;
+        if let Some(cache_manager) = cache_manager {
+            let cache_entry = CacheEntry::new(serialized_data);
+            cache_manager.put(&cache_key, cache_entry)?;
+        }
 
         Ok(result)
     }


### PR DESCRIPTION
## Summary
- make the built-in pre-commit profile actually behave like a pre-commit profile
- scope staged coupling analysis to touched crates and keep it read-only
- clean up pre-commit output and document the validated hook setup

## Verification
- cargo test -q
- cargo clippy --all-targets -- -D warnings
- just install
- validated against the evidia pre-commit hook path (~0.17s direct, ~0.33s through prek)